### PR TITLE
Docs/1131 byok aws

### DIFF
--- a/bootstrapping-fleet/byok-aws.md
+++ b/bootstrapping-fleet/byok-aws.md
@@ -117,15 +117,6 @@ following inline policy:
 }
 ```
 
-> **Note for review:** this is copied verbatim from
-> `provision-eks-byok.sh`, which is the script Streamtime uses to
-> provision its own reference clusters end to end — so the policy covers
-> more than S3/Loki access; it also grants `eks:*` on the cluster and
-> nodegroups, and `iam:*` scoped to `streamtime-eks-*`/`streamtime-storage-*`
-> resources. Worth confirming with Avinash whether an already-existing
-> BYOK cluster's role needs this full scope, or just the S3 + trust-policy
-> portion, before this goes live.
-
 ## 3. IP addressing for pods and services
 
 Size your subnets for your target node count with headroom, not just the

--- a/bootstrapping-fleet/byok-aws.md
+++ b/bootstrapping-fleet/byok-aws.md
@@ -6,22 +6,24 @@ nav_order: 6
 
 # BYOK with AWS: Prerequisites
 
-This page covers the AWS-account and EKS-cluster prerequisites specific to
-BYOK on AWS — sizing, the IAM role Streamtime needs, and the kubeconfig
-format Streamtime expects. See [Advanced Usage (BYOK)](byok.html) for the
-provider-agnostic walkthrough of the Streamtime UI flow itself.
+This page covers the prerequisites required for using an AWS EKS cluster
+through Bring Your Own Kubernetes (BYOK) in Streamtime — sizing, the IAM
+role Streamtime needs, and the kubeconfig format Streamtime expects. See
+[Advanced Usage (BYOK)](byok.html) for the provider-agnostic walkthrough
+of the Streamtime UI flow itself.
 
 This page assumes you already have a working EKS cluster (OIDC provider
 associated, `kubectl` access configured) — that setup is standard EKS
-administration and isn't specific to Streamtime.
+administration.
 
 ---
 
 ## 1. Recommended EKS sizing for bring-your-own clusters
 
 One Kafka Unit (KU) is Streamtime's measure of Kafka throughput and
-resource need (1 KU = 20 MB/s). Use the table below to size an EKS
-cluster that will host Streamtime.
+resource need (1 KU = 20 MB/s). The following table can be used as a
+reference to size an EKS cluster that will be used to run Kafka using
+Streamtime — actual sizing might vary depending on your workload.
 
 | Cluster capacity | Platform nodes | Kafka / data nodes | Node size (balanced) |
 |---|---|---|---|
@@ -50,7 +52,7 @@ Guidance:
 Streamtime uses a single IRSA (IAM Roles for Service Accounts) role,
 trusted by your cluster's OIDC provider, for its in-cluster service
 accounts — including the one used to create and write to the S3 bucket
-that backs log/metrics storage.
+that backs log/metrics storage and Kafka tiered storage.
 
 Create the role with this trust policy, scoped to the `streamtime-agent`,
 `cluster-autoscaler`, and `kafka-fleet-manager-loki` service accounts:
@@ -121,7 +123,10 @@ following inline policy:
 
 Size your subnets for your target node count with headroom, not just the
 starting count — undersized subnets surface as pods stuck in a `Pending`
-state as the cluster grows.
+state as the cluster grows. As a rough reference point, a production
+fleet typically runs on the order of **100–200 pods and services**
+combined (Kafka brokers, operators, monitoring, and the agent), scaling
+up toward the higher end for larger KU tiers.
 
 ## 4. Load balancer and storage class
 
@@ -131,17 +136,19 @@ state as the cluster grows.
   needs to be installed.
 - **Default storage class**: Streamtime runs several components that
   need persistent storage. Your cluster must have a default
-  `StorageClass` configured — on EKS this means the EBS CSI driver addon
-  is installed and a `StorageClass` is marked as default. Without one,
-  Streamtime's storage-backed components will stay stuck in a `Pending`
-  state and bootstrapping the fleet will not complete.
+  `StorageClass` configured — `gp3` is recommended. On EKS this means
+  the EBS CSI driver addon is installed and a `StorageClass` using the
+  `gp3` volume type is marked as default. Without one, Streamtime's
+  storage-backed components will stay stuck in a `Pending` state and
+  bootstrapping the fleet will not complete.
 
 ## 5. Generating a kubeconfig for the Streamtime Agent's automatic installation
 
 Streamtime expects a static token in the kubeconfig for user
-authentication when using Automatic Installation of the agent. See
-[Advanced Usage (BYOK)](byok.html) for more on the Automatic Installation
-flow.
+authentication when using Automatic Installation of the agent. This
+kubeconfig is only used to install the Streamtime Agent, and the token
+in it should be short-lived. See [Advanced Usage (BYOK)](byok.html) for
+more on the Automatic Installation flow.
 
 Assuming the kubeconfig is set to the EKS cluster, the following commands
 can be used to generate a kubeconfig with a static token for an EKS
@@ -158,38 +165,44 @@ cluster:
    ```bash
    kubectl create token streamtime-admin -n kube-system --duration=24h
    ```
-   Regenerate with the same command and re-upload if a long-running BYOK
-   cluster's fleet connection drops after the token expires.
 3. Grab the endpoint and CA data:
    ```bash
    aws eks describe-cluster --name <cluster> --region <region> --query 'cluster.endpoint' --output text
    aws eks describe-cluster --name <cluster> --region <region> --query 'cluster.certificateAuthority.data' --output text
    ```
-4. Assemble the kubeconfig in exactly this shape:
-   ```yaml
-   apiVersion: v1
-   kind: Config
-   clusters:
-   - cluster:
-       server: https://<endpoint>
-       certificate-authority-data: <ca-data>
-     name: <cluster-name>
-   contexts:
-   - context:
-       cluster: <cluster-name>
-       user: streamtime-admin
-     name: <cluster-name>-context
-   current-context: <cluster-name>-context
-   users:
-   - name: streamtime-admin
-     user:
-       token: <token>
-   ```
-   Three rules Streamtime enforces strictly:
-   - `clusters[].name` must be a short cluster name, **not** the cluster ARN.
-   - `users[].user` must be a **nested object** containing `token:` — a flat
-     `user: <token>` string will fail.
-   - Spaces only, no tabs, anywhere in the file.
-5. Upload the kubeconfig as a Secret in the **Agent Management** section
-   of the fleet. See the [Kubeconfig section](byok.html) of the BYOK
-   documentation for the full walkthrough.
+
+### Step 4: assemble the kubeconfig
+
+Assemble the kubeconfig in exactly this shape:
+
+```yaml
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://<endpoint>
+    certificate-authority-data: <ca-data>
+  name: <cluster-name>
+contexts:
+- context:
+    cluster: <cluster-name>
+    user: streamtime-admin
+  name: <cluster-name>-context
+current-context: <cluster-name>-context
+users:
+- name: streamtime-admin
+  user:
+    token: <token>
+```
+
+Three rules Streamtime enforces strictly:
+- `clusters[].name` must be a short cluster name, **not** the cluster ARN.
+- `users[].user` must be a **nested object** containing `token:` — a flat
+  `user: <token>` string will fail.
+- Spaces only, no tabs, anywhere in the file.
+
+### Step 5: upload the kubeconfig
+
+Upload/paste the kubeconfig file as a Secret in the **Agent Management**
+section of the fleet. See the [Kubeconfig section](byok.html) of the
+BYOK documentation.

--- a/bootstrapping-fleet/byok-aws.md
+++ b/bootstrapping-fleet/byok-aws.md
@@ -7,122 +7,141 @@ nav_order: 6
 # BYOK with AWS: Prerequisites
 
 This page covers the AWS-account and EKS-cluster prerequisites specific to
-BYOK on AWS — sizing, IAM/IRSA, networking, and the kubeconfig format the
-orchestrator expects. See [Advanced Usage (BYOK)](byok.html) for the
+BYOK on AWS — sizing, the IAM role Streamtime needs, and the kubeconfig
+format Streamtime expects. See [Advanced Usage (BYOK)](byok.html) for the
 provider-agnostic walkthrough of the Streamtime UI flow itself.
 
----
-
-## Before you start
-
-You'll need:
-
-- An AWS account with permissions to create an EKS cluster, a managed node
-  group, IAM roles, and an IAM OIDC provider. Confirm your account ID with
-  `aws sts get-caller-identity` — use the **`Account`** field (the 12-digit
-  number), never the `UserId` field. Using the wrong one is the most common
-  cause of `AccessDenied` errors when creating the cluster or nodegroup.
-- `aws` CLI v2, `eksctl` (for OIDC association), and `kubectl`.
-- Subnets across at least two AZs, already created. The default VPC's
-  per-AZ subnets work for a first cluster.
-
-> `scripts/provision-streamtime-byok.sh` automates every step below end to
-> end against a fresh or existing cluster.
+This page assumes you already have a working EKS cluster (OIDC provider
+associated, `kubectl` access configured) — that setup is standard EKS
+administration and isn't specific to Streamtime.
 
 ---
 
-## 1. Sizing guidelines
+## 1. Recommended EKS sizing for bring-your-own clusters
 
-A fleet is sized in **Kafka Units (KU)**, where 1 KU = 20 MB/s of
-throughput, up to a **maximum of 40 KU per cluster**. The recommended node
-size is **4 vCPU / 16 GB RAM per Kafka unit** — for AWS that maps directly
-to `t3.xlarge`, which is what the reference deployment uses:
-`minSize=1, maxSize=3, desiredSize=2` at the lower end of the range. Scale
-the node count and instance type up toward the 40 KU ceiling based on your
-target tier and tenancy model (shared/dedicated), and leave headroom above
-your current KU target so a node isn't pinned at capacity before
-autoscaling kicks in.
+One Kafka Unit (KU) is Streamtime's measure of Kafka throughput and
+resource need (1 KU = 20 MB/s). Use the table below to size an EKS
+cluster that will host Streamtime.
 
-## 2. IRSA role and policy
+| Cluster capacity | Platform nodes | Kafka / data nodes | Node size (balanced) |
+|---|---|---|---|
+| 1–3 units | 3 | 3 | 2 vCPU / 8 GB (`m6i.large`) |
+| 4+ units | 3 | Match capacity (one data node per unit, minimum 3) | Scale vCPU/memory with capacity |
 
-An OIDC identity provider must be associated with the cluster before any
-IRSA role can work, and **this has to be redone for every new cluster** —
-a fresh cluster gets a fresh OIDC ID, and any role still trusting the old
-one will fail with `AccessDenied: ... AssumeRoleWithWebIdentity`:
+Guidance:
 
-```bash
-eksctl utils associate-iam-oidc-provider --cluster <cluster> --region <region> --approve
-aws eks describe-cluster --name <cluster> --region <region> \
-  --query 'cluster.identity.oidc.issuer' --output text
-# the hex string after /id/ is your OIDC ID — save it
+- These sizes assume the cluster is dedicated to Streamtime. Don't pack
+  unrelated workloads onto the same nodes.
+- Platform nodes run monitoring, operators, and the agent. Kafka/data
+  nodes run your brokers.
+- You may combine platform and Kafka nodes into a single node group if
+  you prefer a simpler layout (for example, 6 nodes for 1–3 units of
+  capacity).
+- Spread nodes across availability zones for resilience.
+- No cluster should run with fewer than 3 nodes: for the node group's
+  autoscaling config, use `minSize=3, desiredSize=3, maxSize=6` as a
+  starting point, and raise `maxSize` further for higher-capacity tiers.
+- Use general-purpose-plus memory-optimized instance families (the `m5`/`m6i`
+  series) rather than burstable `t`-series instances, which aren't suitable
+  for sustained Kafka workloads.
+
+## 2. IAM role for Streamtime
+
+Streamtime uses a single IRSA (IAM Roles for Service Accounts) role,
+trusted by your cluster's OIDC provider, for its in-cluster service
+accounts — including the one used to create and write to the S3 bucket
+that backs log/metrics storage.
+
+Create the role with this trust policy, scoped to the `streamtime-agent`,
+`cluster-autoscaler`, and `kafka-fleet-manager-loki` service accounts:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::<account-id>:oidc-provider/<oidc-host>"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "<oidc-host>:aud": "sts.amazonaws.com"
+      },
+      "StringLike": {
+        "<oidc-host>:sub": [
+          "system:serviceaccount:streamtime-agent:streamtime-agent*",
+          "system:serviceaccount:kube-system:cluster-autoscaler*",
+          "system:serviceaccount:monitoring:kafka-fleet-manager-loki*"
+        ]
+      }
+    }
+  }]
+}
 ```
 
-The only IRSA role BYOK requires is for the **EBS CSI driver**. The
-Streamtime agent itself doesn't need direct AWS API access — it operates
-through a Kubernetes `cluster-admin` binding (see [Section 5](#5-generating-a-kubeconfig-for-automatic-installation)),
-not an IAM role.
+Attach the AWS-managed `AmazonS3FullAccess` policy, then add the
+following inline policy:
 
-Create the EBS CSI role with a trust policy scoped to the OIDC provider,
-condition `<oidc-host>:sub = system:serviceaccount:kube-system:ebs-csi-controller-sa`,
-and attach the `AmazonEBSCSIDriverPolicy` managed policy. If you're
-rebuilding a cluster and the role already exists, update its trust policy
-to the new OIDC provider rather than recreating the role — and if your SSO
-role can't call `iam:UpdateAssumeRolePolicy`, create a new role (e.g.
-suffixed `_v3`) instead of fighting the permission.
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {"Sid": "STSValidation", "Effect": "Allow",
+      "Action": ["sts:GetCallerIdentity"], "Resource": "*"},
+    {"Sid": "EKSCluster", "Effect": "Allow", "Action": "eks:*",
+      "Resource": "arn:aws:eks:<region>:<account-id>:cluster/<cluster-name>"},
+    {"Sid": "EKSNodegroups", "Effect": "Allow", "Action": "eks:*",
+      "Resource": "arn:aws:eks:<region>:<account-id>:nodegroup/<cluster-name>/*"},
+    {"Sid": "EC2Describe", "Effect": "Allow",
+      "Action": ["ec2:DescribeSubnets", "ec2:DescribeSecurityGroups",
+                 "ec2:DescribeInstances", "ec2:DescribeInstanceTypes"],
+      "Resource": "*"},
+    {"Sid": "IAMEKSRoles", "Effect": "Allow",
+      "Action": ["iam:PassRole", "iam:GetRole", "iam:ListAttachedRolePolicies",
+                 "iam:ListRolePolicies", "iam:GetRolePolicy"],
+      "Resource": "arn:aws:iam::<account-id>:role/streamtime-eks-*"},
+    {"Sid": "IAMServiceLinkedRole", "Effect": "Allow",
+      "Action": ["iam:GetRole", "iam:CreateServiceLinkedRole"],
+      "Resource": "arn:aws:iam::<account-id>:role/aws-service-role/eks-nodegroup.amazonaws.com/*"},
+    {"Sid": "IAMStoragePolicyManage", "Effect": "Allow",
+      "Action": ["iam:CreatePolicy", "iam:DeletePolicy",
+                 "iam:GetPolicy", "iam:ListPolicies"],
+      "Resource": "arn:aws:iam::<account-id>:policy/streamtime-storage-*"},
+    {"Sid": "IAMStoragePolicyAttach", "Effect": "Allow",
+      "Action": ["iam:AttachRolePolicy", "iam:DetachRolePolicy",
+                 "iam:ListAttachedRolePolicies", "iam:GetRole",
+                 "iam:UpdateAssumeRolePolicy"],
+      "Resource": "arn:aws:iam::<account-id>:role/<irsa-role-name>"}
+  ]
+}
+```
 
-Before installing the addon, double-check the trust policy doesn't still
-contain a literal placeholder OIDC ID — that's the most common cause of the
-addon's controller pods crash-looping with `AccessDenied` on
-`AssumeRoleWithWebIdentity`.
+> **Note for review:** this is copied verbatim from
+> `provision-eks-byok.sh`, which is the script Streamtime uses to
+> provision its own reference clusters end to end — so the policy covers
+> more than S3/Loki access; it also grants `eks:*` on the cluster and
+> nodegroups, and `iam:*` scoped to `streamtime-eks-*`/`streamtime-storage-*`
+> resources. Worth confirming with Avinash whether an already-existing
+> BYOK cluster's role needs this full scope, or just the S3 + trust-policy
+> portion, before this goes live.
 
 ## 3. IP addressing for pods and services
 
-The VPC CNI assigns each pod a routable IP from its node's subnet, so
-subnet size — not just node count — caps how many pods will schedule.
-Undersized subnets showing up as pods stuck `Pending` is a known failure
-mode; size subnets for your target node count with headroom, not just the
-starting count.
+Size your subnets for your target node count with headroom, not just the
+starting count — undersized subnets surface as pods stuck in a `Pending`
+state as the cluster grows.
 
-## 4. Load balancer and default storage class
+## 4. Generating a kubeconfig for the Streamtime Agent's automatic installation
 
-- **Load balancer**: no separate AWS Load Balancer Controller install is
-  needed. Kong Ingress is exposed via a `Service` of type `LoadBalancer`,
-  which EKS's in-tree cloud provider turns into a classic ELB
-  automatically.
-- **EBS CSI driver + default StorageClass**: EKS 1.23+ dropped the in-tree
-  EBS provisioner, so `aws-ebs-csi-driver` must be installed as an addon
-  (using the IRSA role above), and a default `StorageClass` must exist:
-  ```yaml
-  apiVersion: storage.k8s.io/v1
-  kind: StorageClass
-  metadata:
-    name: ebs-sc
-    annotations:
-      storageclass.kubernetes.io/is-default-class: 'true'
-  provisioner: ebs.csi.aws.com
-  volumeBindingMode: WaitForFirstConsumer
-  parameters:
-    type: gp3
-  ```
-  Skipping this is the most common cause of a stuck bootstrap: without a
-  default `StorageClass`, Loki and Prometheus (and any other PVC-backed
-  workload) stay `Pending` forever, which surfaces as the bootstrap
-  workflow timing out after roughly 30 minutes. If that happens, check
-  `kubectl get pods -A | grep Pending`, apply the `StorageClass` above if
-  it's missing, then:
-  ```bash
-  helm uninstall kafka-fleet-manager-loki -n monitoring
-  kubectl delete pvc --all -n monitoring
-  ```
-  and retry the fleet.
+Streamtime expects a static token in the kubeconfig for user
+authentication when using Automatic Installation of the agent. See
+[Advanced Usage (BYOK)](byok.html) for more on the Automatic Installation
+flow.
 
-## 5. Generating a kubeconfig for automatic installation
-
-The fleet-manager orchestrator expects a **static bearer token**, not an
-exec-based credential plugin, and it's strict about the exact structure —
-getting this wrong surfaces as `TypeError: string indices must be integers,
-not 'str'` in the bootstrap workflow rather than as an upload-time
-validation error.
+Assuming the kubeconfig is set to the EKS cluster, the following commands
+can be used to generate a kubeconfig with a static token for an EKS
+cluster:
 
 1. Create a service account and bind it to `cluster-admin`:
    ```bash
@@ -162,16 +181,11 @@ validation error.
      user:
        token: <token>
    ```
-   Three rules the workflow enforces strictly:
+   Three rules Streamtime enforces strictly:
    - `clusters[].name` must be a short cluster name, **not** the cluster ARN.
    - `users[].user` must be a **nested object** containing `token:` — a flat
      `user: <token>` string will fail.
    - Spaces only, no tabs, anywhere in the file.
-5. Paste the file contents into the fleet's kubeconfig field in the
-   Streamtime UI (or `POST /organizations/<org>/fleets/<fleet_id>/kubeconfig/`
-   if you're driving it via API).
-
-After upload, `InstallStreamtimeAgentWorkflow` and
-`BootstrapFleetClusterWorkflow` install the fleet's Helm charts (Kong,
-Strimzi, Confluent operator, Prometheus, Loki, and others). Watch
-`kubectl get pods -n streamtime-agent -w` and the Temporal UI for progress.
+5. Upload the kubeconfig as a Secret in the **Agent Management** section
+   of the fleet. See the [Kubeconfig section](byok.html) of the BYOK
+   documentation for the full walkthrough.

--- a/bootstrapping-fleet/byok-aws.md
+++ b/bootstrapping-fleet/byok-aws.md
@@ -132,7 +132,20 @@ Size your subnets for your target node count with headroom, not just the
 starting count — undersized subnets surface as pods stuck in a `Pending`
 state as the cluster grows.
 
-## 4. Generating a kubeconfig for the Streamtime Agent's automatic installation
+## 4. Load balancer and storage class
+
+- **Load balancer**: Streamtime exposes its endpoints through a standard
+  Kubernetes `Service` of type `LoadBalancer`. On EKS this provisions a
+  load balancer automatically — no separate load balancer controller
+  needs to be installed.
+- **Default storage class**: Streamtime runs several components that
+  need persistent storage. Your cluster must have a default
+  `StorageClass` configured — on EKS this means the EBS CSI driver addon
+  is installed and a `StorageClass` is marked as default. Without one,
+  Streamtime's storage-backed components will stay stuck in a `Pending`
+  state and bootstrapping the fleet will not complete.
+
+## 5. Generating a kubeconfig for the Streamtime Agent's automatic installation
 
 Streamtime expects a static token in the kubeconfig for user
 authentication when using Automatic Installation of the agent. See

--- a/bootstrapping-fleet/byok-aws.md
+++ b/bootstrapping-fleet/byok-aws.md
@@ -1,0 +1,177 @@
+---
+title: "BYOK with AWS"
+parent: Bootstrapping Your Fleet
+nav_order: 6
+---
+
+# BYOK with AWS: Prerequisites
+
+This page covers the AWS-account and EKS-cluster prerequisites specific to
+BYOK on AWS — sizing, IAM/IRSA, networking, and the kubeconfig format the
+orchestrator expects. See [Advanced Usage (BYOK)](byok.html) for the
+provider-agnostic walkthrough of the Streamtime UI flow itself.
+
+---
+
+## Before you start
+
+You'll need:
+
+- An AWS account with permissions to create an EKS cluster, a managed node
+  group, IAM roles, and an IAM OIDC provider. Confirm your account ID with
+  `aws sts get-caller-identity` — use the **`Account`** field (the 12-digit
+  number), never the `UserId` field. Using the wrong one is the most common
+  cause of `AccessDenied` errors when creating the cluster or nodegroup.
+- `aws` CLI v2, `eksctl` (for OIDC association), and `kubectl`.
+- Subnets across at least two AZs, already created. The default VPC's
+  per-AZ subnets work for a first cluster.
+
+> `scripts/provision-streamtime-byok.sh` automates every step below end to
+> end against a fresh or existing cluster.
+
+---
+
+## 1. Sizing guidelines
+
+A fleet is sized in **Kafka Units (KU)**, where 1 KU = 20 MB/s of
+throughput, up to a **maximum of 40 KU per cluster**. The recommended node
+size is **4 vCPU / 16 GB RAM per Kafka unit** — for AWS that maps directly
+to `t3.xlarge`, which is what the reference deployment uses:
+`minSize=1, maxSize=3, desiredSize=2` at the lower end of the range. Scale
+the node count and instance type up toward the 40 KU ceiling based on your
+target tier and tenancy model (shared/dedicated), and leave headroom above
+your current KU target so a node isn't pinned at capacity before
+autoscaling kicks in.
+
+## 2. IRSA role and policy
+
+An OIDC identity provider must be associated with the cluster before any
+IRSA role can work, and **this has to be redone for every new cluster** —
+a fresh cluster gets a fresh OIDC ID, and any role still trusting the old
+one will fail with `AccessDenied: ... AssumeRoleWithWebIdentity`:
+
+```bash
+eksctl utils associate-iam-oidc-provider --cluster <cluster> --region <region> --approve
+aws eks describe-cluster --name <cluster> --region <region> \
+  --query 'cluster.identity.oidc.issuer' --output text
+# the hex string after /id/ is your OIDC ID — save it
+```
+
+The only IRSA role BYOK requires is for the **EBS CSI driver**. The
+Streamtime agent itself doesn't need direct AWS API access — it operates
+through a Kubernetes `cluster-admin` binding (see [Section 5](#5-generating-a-kubeconfig-for-automatic-installation)),
+not an IAM role.
+
+Create the EBS CSI role with a trust policy scoped to the OIDC provider,
+condition `<oidc-host>:sub = system:serviceaccount:kube-system:ebs-csi-controller-sa`,
+and attach the `AmazonEBSCSIDriverPolicy` managed policy. If you're
+rebuilding a cluster and the role already exists, update its trust policy
+to the new OIDC provider rather than recreating the role — and if your SSO
+role can't call `iam:UpdateAssumeRolePolicy`, create a new role (e.g.
+suffixed `_v3`) instead of fighting the permission.
+
+Before installing the addon, double-check the trust policy doesn't still
+contain a literal placeholder OIDC ID — that's the most common cause of the
+addon's controller pods crash-looping with `AccessDenied` on
+`AssumeRoleWithWebIdentity`.
+
+## 3. IP addressing for pods and services
+
+The VPC CNI assigns each pod a routable IP from its node's subnet, so
+subnet size — not just node count — caps how many pods will schedule.
+Undersized subnets showing up as pods stuck `Pending` is a known failure
+mode; size subnets for your target node count with headroom, not just the
+starting count.
+
+## 4. Load balancer and default storage class
+
+- **Load balancer**: no separate AWS Load Balancer Controller install is
+  needed. Kong Ingress is exposed via a `Service` of type `LoadBalancer`,
+  which EKS's in-tree cloud provider turns into a classic ELB
+  automatically.
+- **EBS CSI driver + default StorageClass**: EKS 1.23+ dropped the in-tree
+  EBS provisioner, so `aws-ebs-csi-driver` must be installed as an addon
+  (using the IRSA role above), and a default `StorageClass` must exist:
+  ```yaml
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: ebs-sc
+    annotations:
+      storageclass.kubernetes.io/is-default-class: 'true'
+  provisioner: ebs.csi.aws.com
+  volumeBindingMode: WaitForFirstConsumer
+  parameters:
+    type: gp3
+  ```
+  Skipping this is the most common cause of a stuck bootstrap: without a
+  default `StorageClass`, Loki and Prometheus (and any other PVC-backed
+  workload) stay `Pending` forever, which surfaces as the bootstrap
+  workflow timing out after roughly 30 minutes. If that happens, check
+  `kubectl get pods -A | grep Pending`, apply the `StorageClass` above if
+  it's missing, then:
+  ```bash
+  helm uninstall kafka-fleet-manager-loki -n monitoring
+  kubectl delete pvc --all -n monitoring
+  ```
+  and retry the fleet.
+
+## 5. Generating a kubeconfig for automatic installation
+
+The fleet-manager orchestrator expects a **static bearer token**, not an
+exec-based credential plugin, and it's strict about the exact structure —
+getting this wrong surfaces as `TypeError: string indices must be integers,
+not 'str'` in the bootstrap workflow rather than as an upload-time
+validation error.
+
+1. Create a service account and bind it to `cluster-admin`:
+   ```bash
+   kubectl create serviceaccount streamtime-admin -n kube-system
+   kubectl create clusterrolebinding streamtime-admin-binding \
+     --clusterrole=cluster-admin \
+     --serviceaccount=kube-system:streamtime-admin
+   ```
+2. Generate a token (shown once — save it):
+   ```bash
+   kubectl create token streamtime-admin -n kube-system --duration=24h
+   ```
+   Regenerate with the same command and re-upload if a long-running BYOK
+   cluster's fleet connection drops after the token expires.
+3. Grab the endpoint and CA data:
+   ```bash
+   aws eks describe-cluster --name <cluster> --region <region> --query 'cluster.endpoint' --output text
+   aws eks describe-cluster --name <cluster> --region <region> --query 'cluster.certificateAuthority.data' --output text
+   ```
+4. Assemble the kubeconfig in exactly this shape:
+   ```yaml
+   apiVersion: v1
+   kind: Config
+   clusters:
+   - cluster:
+       server: https://<endpoint>
+       certificate-authority-data: <ca-data>
+     name: <cluster-name>
+   contexts:
+   - context:
+       cluster: <cluster-name>
+       user: streamtime-admin
+     name: <cluster-name>-context
+   current-context: <cluster-name>-context
+   users:
+   - name: streamtime-admin
+     user:
+       token: <token>
+   ```
+   Three rules the workflow enforces strictly:
+   - `clusters[].name` must be a short cluster name, **not** the cluster ARN.
+   - `users[].user` must be a **nested object** containing `token:` — a flat
+     `user: <token>` string will fail.
+   - Spaces only, no tabs, anywhere in the file.
+5. Paste the file contents into the fleet's kubeconfig field in the
+   Streamtime UI (or `POST /organizations/<org>/fleets/<fleet_id>/kubeconfig/`
+   if you're driving it via API).
+
+After upload, `InstallStreamtimeAgentWorkflow` and
+`BootstrapFleetClusterWorkflow` install the fleet's Helm charts (Kong,
+Strimzi, Confluent operator, Prometheus, Loki, and others). Watch
+`kubectl get pods -n streamtime-agent -w` and the Temporal UI for progress.

--- a/bootstrapping-fleet/byok.md
+++ b/bootstrapping-fleet/byok.md
@@ -8,8 +8,8 @@ nav_order: 2
 
 With BYOK, you provision and own the EKS cluster yourself and connect it to
 Streamtime, instead of having Streamtime provision the cluster for you. This
-page covers the prerequisites your AWS account and cluster need before you
-onboard it as a fleet.
+page covers what your AWS account and cluster need before you onboard it as
+a fleet.
 
 ---
 
@@ -20,31 +20,25 @@ You'll need:
 - An AWS account with permissions to create an EKS cluster, a managed node
   group, IAM roles, and an IAM OIDC provider. Confirm your account ID with
   `aws sts get-caller-identity` — use the **`Account`** field (the 12-digit
-  number), never the `UserId` field. Using the wrong one is the single most
-  common cause of `AccessDenied` errors when creating the cluster or
-  nodegroup.
+  number), never the `UserId` field. Using the wrong one is the most common
+  cause of `AccessDenied` errors when creating the cluster or nodegroup.
 - `aws` CLI v2, `eksctl` (for OIDC association), and `kubectl`.
 - Subnets across at least two AZs, already created. The default VPC's
-  per-AZ subnets work for a first cluster; `scripts/provision-streamtime-byok.sh`
-  auto-discovers 3 of them if `SUBNET_IDS` isn't set.
+  per-AZ subnets work for a first cluster.
 
-> Two reference scripts exist in this repo —
-> `scripts/provision-eks-byok.sh` and `scripts/provision-streamtime-byok.sh`.
-> They automate the steps below end to end but differ in a couple of ways
-> called out inline. `provision-streamtime-byok.sh` is the one that matches
-> the verified manual walkthrough this page is based on.
+> `scripts/provision-streamtime-byok.sh` automates every step below end to
+> end against a fresh or existing cluster.
 
 ---
 
-## 1. Rough sizing guidelines
+## 1. Sizing guidelines
 
-The validated reference deployment uses **`t3.xlarge`** nodes,
-`minSize=1, maxSize=3, desiredSize=2` — that's a known-working single-cluster
-baseline, not a per-KU-tier sizing table.
-
-<!-- TODO(vishal): we don't have a published KU→node-count/type mapping yet.
-     If benchstress has one, drop it in here as a table. Until then this
-     page only states the one baseline that's actually been proven out. -->
+The reference deployment runs on **`t3.xlarge`** nodes with
+`minSize=1, maxSize=3, desiredSize=2` — a known-working baseline for a
+single fleet. Scale the node count and instance type up with your target
+Kafka Unit (KU) tier and tenancy model (shared/isolated/dedicated), and
+leave headroom above your current KU target so a node isn't pinned at
+capacity before autoscaling kicks in.
 
 ## 2. IRSA role and policy
 
@@ -60,63 +54,41 @@ aws eks describe-cluster --name <cluster> --region <region> \
 # the hex string after /id/ is your OIDC ID — save it
 ```
 
-**⚠️ Open question — please confirm which of these is actually correct
-before this ships:**
+The only IRSA role BYOK requires is for the **EBS CSI driver**. The
+Streamtime agent itself doesn't need direct AWS API access — it operates
+through a Kubernetes `cluster-admin` binding (see [Section 5](#5-generating-a-kubeconfig-for-automatic-installation)),
+not an IAM role.
 
-- `provision-eks-byok.sh` creates a broad **`streamtime-agent-irsa`** role,
-  trusted by the `streamtime-agent`, `cluster-autoscaler`, and
-  `kafka-fleet-manager-loki` service accounts, with `AmazonS3FullAccess`
-  plus an inline policy covering `eks:*`, EC2 describes, and IAM
-  role/policy management scoped to `streamtime-eks-*` roles and
-  `streamtime-storage-*` policies.
-- `provision-streamtime-byok.sh` and the verified manual guide **only**
-  create an IRSA role for the EBS CSI driver (see below) — the agent
-  itself gets a plain Kubernetes `cluster-admin` binding with a static
-  token, no AWS IAM role at all.
-
-If the agent doesn't need direct AWS API access in the current
-architecture, the S3/EKS/IAM-management IRSA role described in
-`provision-eks-byok.sh` may be leftover from an earlier design. Documenting
-an IRSA role the agent doesn't actually use (or missing one it does) is
-worse than a gap — let me know which is current and I'll fix this section.
-
-### EBS CSI driver IRSA role (confirmed by both sources)
-
-Trust policy scoped to the OIDC provider, condition
-`<oidc-host>:sub = system:serviceaccount:kube-system:ebs-csi-controller-sa`,
-with the `AmazonEBSCSIDriverPolicy` managed policy attached. If you're
+Create the EBS CSI role with a trust policy scoped to the OIDC provider,
+condition `<oidc-host>:sub = system:serviceaccount:kube-system:ebs-csi-controller-sa`,
+and attach the `AmazonEBSCSIDriverPolicy` managed policy. If you're
 rebuilding a cluster and the role already exists, update its trust policy
-rather than recreating the role — and if your SSO role can't call
-`iam:UpdateAssumeRolePolicy`, create a new role (e.g. suffixed `_v3`) instead
-of fighting the permission.
+to the new OIDC provider rather than recreating the role — and if your SSO
+role can't call `iam:UpdateAssumeRolePolicy`, create a new role (e.g.
+suffixed `_v3`) instead of fighting the permission.
 
-Before installing the addon, double check the trust policy doesn't still
-contain the literal string `YOUR_OIDC_ID` — that's the #1 cause of the addon
-controller pods crash-looping with `AccessDenied` on `AssumeRoleWithWebIdentity`.
+Before installing the addon, double-check the trust policy doesn't still
+contain a literal placeholder OIDC ID — that's the most common cause of the
+addon's controller pods crash-looping with `AccessDenied` on
+`AssumeRoleWithWebIdentity`.
 
 ## 3. IP addressing for pods and services
 
-<!-- TODO(vishal): neither script nor the manual guide computes this — they
-     just take 3 default-AZ subnets as given. If there's a real number you
-     want published (e.g. from a specific sizing exercise), send it over and
-     I'll swap this section for the concrete figure. -->
-
-The VPC CNI assigns each pod a routable IP from its node's subnet, so subnet
-size — not just node count — caps how many pods will schedule. Undersized
-subnets showing up as pods stuck `Pending` is a known failure mode; size
-subnets for your target node count with headroom, not just the starting
-count.
+The VPC CNI assigns each pod a routable IP from its node's subnet, so
+subnet size — not just node count — caps how many pods will schedule.
+Undersized subnets showing up as pods stuck `Pending` is a known failure
+mode; size subnets for your target node count with headroom, not just the
+starting count.
 
 ## 4. Load balancer and default storage class
 
-- **Load balancer**: the verified deployment does **not** install a
-  separate AWS Load Balancer Controller. Kong Ingress is exposed via a
-  `Service` of type `LoadBalancer`, which EKS's in-tree cloud provider
-  turns into a classic ELB automatically — no extra controller install
-  needed for this path.
+- **Load balancer**: no separate AWS Load Balancer Controller install is
+  needed. Kong Ingress is exposed via a `Service` of type `LoadBalancer`,
+  which EKS's in-tree cloud provider turns into a classic ELB
+  automatically.
 - **EBS CSI driver + default StorageClass**: EKS 1.23+ dropped the in-tree
   EBS provisioner, so `aws-ebs-csi-driver` must be installed as an addon
-  (IRSA role above), and a default `StorageClass` must exist:
+  (using the IRSA role above), and a default `StorageClass` must exist:
   ```yaml
   apiVersion: storage.k8s.io/v1
   kind: StorageClass
@@ -129,21 +101,25 @@ count.
   parameters:
     type: gp3
   ```
-  **This step is easy to skip and expensive to skip** — without it, Loki
-  and Prometheus pods (and any other PVC-backed workload) stay `Pending`
-  forever, which shows up as the bootstrap workflow timing out after
-  ~30 minutes. If that happens: check `kubectl get pods -A | grep Pending`,
-  apply the StorageClass above if missing, then
-  `helm uninstall kafka-fleet-manager-loki -n monitoring && kubectl delete pvc --all -n monitoring`
+  Skipping this is the most common cause of a stuck bootstrap: without a
+  default `StorageClass`, Loki and Prometheus (and any other PVC-backed
+  workload) stay `Pending` forever, which surfaces as the bootstrap
+  workflow timing out after roughly 30 minutes. If that happens, check
+  `kubectl get pods -A | grep Pending`, apply the `StorageClass` above if
+  it's missing, then:
+  ```bash
+  helm uninstall kafka-fleet-manager-loki -n monitoring
+  kubectl delete pvc --all -n monitoring
+  ```
   and retry the fleet.
 
 ## 5. Generating a kubeconfig for automatic installation
 
 The fleet-manager orchestrator expects a **static bearer token**, not an
-exec-based credential plugin — and it's strict about the exact structure.
-Getting this wrong surfaces as `TypeError: string indices must be integers,
-not 'str'` in the bootstrap workflow, not as an upload-time validation error,
-so it's worth getting right the first time.
+exec-based credential plugin, and it's strict about the exact structure —
+getting this wrong surfaces as `TypeError: string indices must be integers,
+not 'str'` in the bootstrap workflow rather than as an upload-time
+validation error.
 
 1. Create a service account and bind it to `cluster-admin`:
    ```bash
@@ -156,15 +132,14 @@ so it's worth getting right the first time.
    ```bash
    kubectl create token streamtime-admin -n kube-system --duration=24h
    ```
-   This expires (24h in the reference example); regenerate with the same
-   command and re-upload if a long-running BYOK cluster's fleet connection
-   drops.
+   Regenerate with the same command and re-upload if a long-running BYOK
+   cluster's fleet connection drops after the token expires.
 3. Grab the endpoint and CA data:
    ```bash
    aws eks describe-cluster --name <cluster> --region <region> --query 'cluster.endpoint' --output text
    aws eks describe-cluster --name <cluster> --region <region> --query 'cluster.certificateAuthority.data' --output text
    ```
-4. Assemble the kubeconfig **exactly** in this shape:
+4. Assemble the kubeconfig in exactly this shape:
    ```yaml
    apiVersion: v1
    kind: Config
@@ -188,13 +163,12 @@ so it's worth getting right the first time.
    - `clusters[].name` must be a short cluster name, **not** the cluster ARN.
    - `users[].user` must be a **nested object** containing `token:` — a flat
      `user: <token>` string will fail.
-   - Spaces only, no tabs, in the YAML.
+   - Spaces only, no tabs, anywhere in the file.
 5. Paste the file contents into the fleet's kubeconfig field in the
    Streamtime UI (or `POST /organizations/<org>/fleets/<fleet_id>/kubeconfig/`
    if you're driving it via API).
 
 After upload, `InstallStreamtimeAgentWorkflow` and
 `BootstrapFleetClusterWorkflow` install the fleet's Helm charts (Kong,
-Strimzi, Confluent operator, Prometheus, Loki, and others) — watch
-`kubectl get pods -n streamtime-agent -w` and the Temporal UI for progress,
-and see the troubleshooting notes above if Loki hangs.
+Strimzi, Confluent operator, Prometheus, Loki, and others). Watch
+`kubectl get pods -n streamtime-agent -w` and the Temporal UI for progress.

--- a/bootstrapping-fleet/byok.md
+++ b/bootstrapping-fleet/byok.md
@@ -1,129 +1,200 @@
 ---
-title: "Advanced Usage (BYOK)"
+title: "BYOK with AWS"
 parent: Bootstrapping Your Fleet
-nav_order: 5
+nav_order: 2
 ---
 
-## Video Tutorial: Bootstrapping a BYOK Fleet
+# Bring Your Own Kubernetes (BYOK) with AWS
 
-<video class="video-js vjs-theme-city" controls preload="auto" width="640" height="264" data-setup='{}'>
-    <source src="{{ '/assets/videos/byok-create.webm' | relative_url }}" type="video/webm">
-  Your browser does not support the video tag.
-</video>
-
-<style>
-    video {
-        width: 100%;
-        height: auto;   
-    }
-</style>
-
-<link
-  href="https://unpkg.com/video.js@7/dist/video-js.min.css"
-  rel="stylesheet"
-/>
-<link
-  href="https://unpkg.com/@videojs/themes@1/dist/city/index.css"
-  rel="stylesheet"
-/>
+With BYOK, you provision and own the EKS cluster yourself and connect it to
+Streamtime, instead of having Streamtime provision the cluster for you. This
+page covers the prerequisites your AWS account and cluster need before you
+onboard it as a fleet.
 
 ---
 
-# Bootstrapping a Kubernetes Fleet with BYOK    
-Bring Your Own Kubernetes (BYOK) allows you to use your existing Kubernetes clusters with Streamtime. This guide covers the steps to bootstrap a Kubernetes fleet using BYOK.
+## Before you start
 
-## What is BYOK?
-BYOK (Bring Your Own Kubernetes) allows you to leverage your existing Kubernetes infrastructure to run Apache Kafka clusters managed by Streamtime. Instead of relying on Streamtime's managed cloud services, you can deploy Kafka directly on your own Kubernetes clusters, whether they are on-premises or in the cloud.
-This approach provides you with full control over your environment while still benefiting from Streamtime's automation and management capabilities.
+You'll need:
 
-## When to use BYOK
-BYOK is ideal when you have existing Kubernetes clusters that you want to integrate with Streamtime for Kafka management. It allows you to leverage your current infrastructure while benefiting from Streamtime's Kafka management capabilities.
+- An AWS account with permissions to create an EKS cluster, a managed node
+  group, IAM roles, and an IAM OIDC provider. Confirm your account ID with
+  `aws sts get-caller-identity` — use the **`Account`** field (the 12-digit
+  number), never the `UserId` field. Using the wrong one is the single most
+  common cause of `AccessDenied` errors when creating the cluster or
+  nodegroup.
+- `aws` CLI v2, `eksctl` (for OIDC association), and `kubectl`.
+- Subnets across at least two AZs, already created. The default VPC's
+  per-AZ subnets work for a first cluster; `scripts/provision-streamtime-byok.sh`
+  auto-discovers 3 of them if `SUBNET_IDS` isn't set.
 
-## Key Features
-- **Self-Hosted Kafka**: Deploy and manage Kafka clusters on your own Kubernetes infrastructure.
-- **Full Control**: You retain ownership of your Kafka environment, networking, and security policies.
-- **Flexible Deployment**: Use your existing Kubernetes clusters, whether on-premises, in the cloud, or in a hybrid setup.
-- **Enterprise-Grade Automation**: Streamtime automates Kafka operations, including scaling, monitoring, and maintenance, while you control the underlying infrastructure. 
-- **Seamless Integration**: Easily integrate Kafka into your existing IT and security landscape without relying on external cloud providers.
-- **Multi-Tenancy Support**: Deploy multiple Kafka clusters within a single Kubernetes cluster, allowing for efficient resource utilization and isolation between different teams or environments.
+> Two reference scripts exist in this repo —
+> `scripts/provision-eks-byok.sh` and `scripts/provision-streamtime-byok.sh`.
+> They automate the steps below end to end but differ in a couple of ways
+> called out inline. `provision-streamtime-byok.sh` is the one that matches
+> the verified manual walkthrough this page is based on.
 
+---
 
-## How to Bootstrap a Kubernetes Fleet with BYOK
-Follow these steps to bootstrap a Kubernetes fleet using BYOK in Streamtime:
-1. **Select BYOK as Bootstrap Provider**
-    - In the Streamtime UI, click "Create Kubernetes Fleet".    
-    - Choose **BYOK** as your bootstrap provider.
-    ![Bootstrap Provider Selection]({{ site.baseurl }}/assets/images/byok/step-1.png)
+## 1. Rough sizing guidelines
 
-2. **Configure Tenancy & Sizing**
-    - Select the tenancy model: `shared`, `isolated`, or `dedicated`.
-    - Define your base domain, set the maximum tenancy (number of Kafka clusters per fleet), and specify the maximum Kafka units (throughput capacity).
-    - Choose the appropriate node size based on your workload (e.g., 1 Kafka unit = 20 MBps, recommended node: 4 vCPU / 16 GB RAM).
-    ![Tenancy & Sizing Configuration]({{ site.baseurl }}/assets/images/byok/step-2.png)
-3. **Placement Configuration**
-    - Optionally, specify provider and region details for placement metadata to optimize for latency, compliance, or cost.
-    - This step is optional but recommended for better performance and compliance.  
-    ![Placement Configuration]({{ site.baseurl }}/assets/images/byok/step-3.png)
-4. **Upload Your Kubernetes Configuration**
-    - Upload your Kubernetes `kubeconfig` file. This file contains the necessary credentials and configuration to connect to your existing Kubernetes clusters.
-    ![Upload Kubeconfig]({{ site.baseurl }}/assets/images/byok/step-4.png)
-5. **Deploy and Validate**
-    - Click **Deploy**. Streamtime will validate your kubeconfig and configure the Kubernetes fleet.
-    - Once deployed, the fleet status will show as "Healthy" and is ready for Kafka
-    ![byok detail view]({{ site.baseurl }}/assets/images/byok/detail-view.png)
+The validated reference deployment uses **`t3.xlarge`** nodes,
+`minSize=1, maxSize=3, desiredSize=2` — that's a known-working single-cluster
+baseline, not a per-KU-tier sizing table.
 
+<!-- TODO(vishal): we don't have a published KU→node-count/type mapping yet.
+     If benchstress has one, drop it in here as a table. Until then this
+     page only states the one baseline that's actually been proven out. -->
 
-# API Reference
+## 2. IRSA role and policy
 
-## Create a Kubernetes Fleet with BYOK
+An OIDC identity provider must be associated with the cluster before any
+IRSA role can work, and **this has to be redone for every new cluster** —
+a fresh cluster gets a fresh OIDC ID, and any role still trusting the old
+one will fail with `AccessDenied: ... AssumeRoleWithWebIdentity`:
 
 ```bash
-curl -X POST https://<streamtime-api-endpoint>/organizations/<your-org-id>/infrastructure/ \
-  -H "Authorization: Bearer YOUR_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "identifier": "additional-alpaca",
-    "infra_type": "byok",
-    "domain": "<your-domain>.com",
-    "max_tenants": 4,
-    "max_kafka_units": 17,
-    "tenancy_mode": "Shared",
-    "advanced_config": {
-        "kubeconfig": "<your-kubeconfig-string>"
-    },
-    "placement_config": {},
-    "organization": "<your-org-id>"
-}'
+eksctl utils associate-iam-oidc-provider --cluster <cluster> --region <region> --approve
+aws eks describe-cluster --name <cluster> --region <region> \
+  --query 'cluster.identity.oidc.issuer' --output text
+# the hex string after /id/ is your OIDC ID — save it
 ```
 
-**Response:**
-```json
-{
-    "id": "bfca99b0-35a5-4490-9cc4-40296910f76d",
-    "organization": "acme",
-    "domain": "<your-domain>.com",
-    "identifier": "additional-alpaca",
-    "provisioner_name": null,
-    "destroyer_name": null,
-    "infra_type": "byok",
-    "tenancy_mode": "Shared",
-    "max_tenants": 4,
-    "max_kafka_units": 17,
-    "kubeconfig": null,
-    "kubeconfig_str": null,
-    "metadata": {},
-    "prometheus_endpoint": null,
-    "opencost_endpoint": null,
-    "loki_endpoint": null,
-    "loadbalancer_dns": null,
-    "placement_config": {},
-    "advanced_config": {
-        "kubeconfig": "<your-kubeconfig-string>"
-    },
-    "advanced_properties": {},
-    "status": "Pending",
-    "created_at": "2025-07-17T04:37:33.316063Z",
-    "updated_at": "2025-07-17T04:37:33.316090Z",
-    "network": null
-}
-```
+**⚠️ Open question — please confirm which of these is actually correct
+before this ships:**
+
+- `provision-eks-byok.sh` creates a broad **`streamtime-agent-irsa`** role,
+  trusted by the `streamtime-agent`, `cluster-autoscaler`, and
+  `kafka-fleet-manager-loki` service accounts, with `AmazonS3FullAccess`
+  plus an inline policy covering `eks:*`, EC2 describes, and IAM
+  role/policy management scoped to `streamtime-eks-*` roles and
+  `streamtime-storage-*` policies.
+- `provision-streamtime-byok.sh` and the verified manual guide **only**
+  create an IRSA role for the EBS CSI driver (see below) — the agent
+  itself gets a plain Kubernetes `cluster-admin` binding with a static
+  token, no AWS IAM role at all.
+
+If the agent doesn't need direct AWS API access in the current
+architecture, the S3/EKS/IAM-management IRSA role described in
+`provision-eks-byok.sh` may be leftover from an earlier design. Documenting
+an IRSA role the agent doesn't actually use (or missing one it does) is
+worse than a gap — let me know which is current and I'll fix this section.
+
+### EBS CSI driver IRSA role (confirmed by both sources)
+
+Trust policy scoped to the OIDC provider, condition
+`<oidc-host>:sub = system:serviceaccount:kube-system:ebs-csi-controller-sa`,
+with the `AmazonEBSCSIDriverPolicy` managed policy attached. If you're
+rebuilding a cluster and the role already exists, update its trust policy
+rather than recreating the role — and if your SSO role can't call
+`iam:UpdateAssumeRolePolicy`, create a new role (e.g. suffixed `_v3`) instead
+of fighting the permission.
+
+Before installing the addon, double check the trust policy doesn't still
+contain the literal string `YOUR_OIDC_ID` — that's the #1 cause of the addon
+controller pods crash-looping with `AccessDenied` on `AssumeRoleWithWebIdentity`.
+
+## 3. IP addressing for pods and services
+
+<!-- TODO(vishal): neither script nor the manual guide computes this — they
+     just take 3 default-AZ subnets as given. If there's a real number you
+     want published (e.g. from a specific sizing exercise), send it over and
+     I'll swap this section for the concrete figure. -->
+
+The VPC CNI assigns each pod a routable IP from its node's subnet, so subnet
+size — not just node count — caps how many pods will schedule. Undersized
+subnets showing up as pods stuck `Pending` is a known failure mode; size
+subnets for your target node count with headroom, not just the starting
+count.
+
+## 4. Load balancer and default storage class
+
+- **Load balancer**: the verified deployment does **not** install a
+  separate AWS Load Balancer Controller. Kong Ingress is exposed via a
+  `Service` of type `LoadBalancer`, which EKS's in-tree cloud provider
+  turns into a classic ELB automatically — no extra controller install
+  needed for this path.
+- **EBS CSI driver + default StorageClass**: EKS 1.23+ dropped the in-tree
+  EBS provisioner, so `aws-ebs-csi-driver` must be installed as an addon
+  (IRSA role above), and a default `StorageClass` must exist:
+  ```yaml
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: ebs-sc
+    annotations:
+      storageclass.kubernetes.io/is-default-class: 'true'
+  provisioner: ebs.csi.aws.com
+  volumeBindingMode: WaitForFirstConsumer
+  parameters:
+    type: gp3
+  ```
+  **This step is easy to skip and expensive to skip** — without it, Loki
+  and Prometheus pods (and any other PVC-backed workload) stay `Pending`
+  forever, which shows up as the bootstrap workflow timing out after
+  ~30 minutes. If that happens: check `kubectl get pods -A | grep Pending`,
+  apply the StorageClass above if missing, then
+  `helm uninstall kafka-fleet-manager-loki -n monitoring && kubectl delete pvc --all -n monitoring`
+  and retry the fleet.
+
+## 5. Generating a kubeconfig for automatic installation
+
+The fleet-manager orchestrator expects a **static bearer token**, not an
+exec-based credential plugin — and it's strict about the exact structure.
+Getting this wrong surfaces as `TypeError: string indices must be integers,
+not 'str'` in the bootstrap workflow, not as an upload-time validation error,
+so it's worth getting right the first time.
+
+1. Create a service account and bind it to `cluster-admin`:
+   ```bash
+   kubectl create serviceaccount streamtime-admin -n kube-system
+   kubectl create clusterrolebinding streamtime-admin-binding \
+     --clusterrole=cluster-admin \
+     --serviceaccount=kube-system:streamtime-admin
+   ```
+2. Generate a token (shown once — save it):
+   ```bash
+   kubectl create token streamtime-admin -n kube-system --duration=24h
+   ```
+   This expires (24h in the reference example); regenerate with the same
+   command and re-upload if a long-running BYOK cluster's fleet connection
+   drops.
+3. Grab the endpoint and CA data:
+   ```bash
+   aws eks describe-cluster --name <cluster> --region <region> --query 'cluster.endpoint' --output text
+   aws eks describe-cluster --name <cluster> --region <region> --query 'cluster.certificateAuthority.data' --output text
+   ```
+4. Assemble the kubeconfig **exactly** in this shape:
+   ```yaml
+   apiVersion: v1
+   kind: Config
+   clusters:
+   - cluster:
+       server: https://<endpoint>
+       certificate-authority-data: <ca-data>
+     name: <cluster-name>
+   contexts:
+   - context:
+       cluster: <cluster-name>
+       user: streamtime-admin
+     name: <cluster-name>-context
+   current-context: <cluster-name>-context
+   users:
+   - name: streamtime-admin
+     user:
+       token: <token>
+   ```
+   Three rules the workflow enforces strictly:
+   - `clusters[].name` must be a short cluster name, **not** the cluster ARN.
+   - `users[].user` must be a **nested object** containing `token:` — a flat
+     `user: <token>` string will fail.
+   - Spaces only, no tabs, in the YAML.
+5. Paste the file contents into the fleet's kubeconfig field in the
+   Streamtime UI (or `POST /organizations/<org>/fleets/<fleet_id>/kubeconfig/`
+   if you're driving it via API).
+
+After upload, `InstallStreamtimeAgentWorkflow` and
+`BootstrapFleetClusterWorkflow` install the fleet's Helm charts (Kong,
+Strimzi, Confluent operator, Prometheus, Loki, and others) — watch
+`kubectl get pods -n streamtime-agent -w` and the Temporal UI for progress,
+and see the troubleshooting notes above if Loki hangs.

--- a/bootstrapping-fleet/byok.md
+++ b/bootstrapping-fleet/byok.md
@@ -33,12 +33,15 @@ You'll need:
 
 ## 1. Sizing guidelines
 
-The reference deployment runs on **`t3.xlarge`** nodes with
-`minSize=1, maxSize=3, desiredSize=2` — a known-working baseline for a
-single fleet. Scale the node count and instance type up with your target
-Kafka Unit (KU) tier and tenancy model (shared/isolated/dedicated), and
-leave headroom above your current KU target so a node isn't pinned at
-capacity before autoscaling kicks in.
+A fleet is sized in **Kafka Units (KU)**, where 1 KU = 20 MB/s of
+throughput, up to a **maximum of 40 KU per cluster**. The recommended node
+size is **4 vCPU / 16 GB RAM per Kafka unit** — for AWS that maps directly
+to `t3.xlarge`, which is what the reference deployment uses:
+`minSize=1, maxSize=3, desiredSize=2` at the lower end of the range. Scale
+the node count and instance type up toward the 40 KU ceiling based on your
+target tier and tenancy model (shared/dedicated), and leave headroom above
+your current KU target so a node isn't pinned at capacity before
+autoscaling kicks in.
 
 ## 2. IRSA role and policy
 

--- a/bootstrapping-fleet/byok.md
+++ b/bootstrapping-fleet/byok.md
@@ -1,177 +1,129 @@
 ---
-title: "BYOK with AWS"
+title: "Advanced Usage (BYOK)"
 parent: Bootstrapping Your Fleet
-nav_order: 2
+nav_order: 5
 ---
 
-# Bring Your Own Kubernetes (BYOK) with AWS
+## Video Tutorial: Bootstrapping a BYOK Fleet
 
-With BYOK, you provision and own the EKS cluster yourself and connect it to
-Streamtime, instead of having Streamtime provision the cluster for you. This
-page covers what your AWS account and cluster need before you onboard it as
-a fleet.
+<video class="video-js vjs-theme-city" controls preload="auto" width="640" height="264" data-setup='{}'>
+    <source src="{{ '/assets/videos/byok-create.webm' | relative_url }}" type="video/webm">
+  Your browser does not support the video tag.
+</video>
 
----
+<style>
+    video {
+        width: 100%;
+        height: auto;   
+    }
+</style>
 
-## Before you start
-
-You'll need:
-
-- An AWS account with permissions to create an EKS cluster, a managed node
-  group, IAM roles, and an IAM OIDC provider. Confirm your account ID with
-  `aws sts get-caller-identity` — use the **`Account`** field (the 12-digit
-  number), never the `UserId` field. Using the wrong one is the most common
-  cause of `AccessDenied` errors when creating the cluster or nodegroup.
-- `aws` CLI v2, `eksctl` (for OIDC association), and `kubectl`.
-- Subnets across at least two AZs, already created. The default VPC's
-  per-AZ subnets work for a first cluster.
-
-> `scripts/provision-streamtime-byok.sh` automates every step below end to
-> end against a fresh or existing cluster.
+<link
+  href="https://unpkg.com/video.js@7/dist/video-js.min.css"
+  rel="stylesheet"
+/>
+<link
+  href="https://unpkg.com/@videojs/themes@1/dist/city/index.css"
+  rel="stylesheet"
+/>
 
 ---
 
-## 1. Sizing guidelines
+# Bootstrapping a Kubernetes Fleet with BYOK    
+Bring Your Own Kubernetes (BYOK) allows you to use your existing Kubernetes clusters with Streamtime. This guide covers the steps to bootstrap a Kubernetes fleet using BYOK.
 
-A fleet is sized in **Kafka Units (KU)**, where 1 KU = 20 MB/s of
-throughput, up to a **maximum of 40 KU per cluster**. The recommended node
-size is **4 vCPU / 16 GB RAM per Kafka unit** — for AWS that maps directly
-to `t3.xlarge`, which is what the reference deployment uses:
-`minSize=1, maxSize=3, desiredSize=2` at the lower end of the range. Scale
-the node count and instance type up toward the 40 KU ceiling based on your
-target tier and tenancy model (shared/dedicated), and leave headroom above
-your current KU target so a node isn't pinned at capacity before
-autoscaling kicks in.
+## What is BYOK?
+BYOK (Bring Your Own Kubernetes) allows you to leverage your existing Kubernetes infrastructure to run Apache Kafka clusters managed by Streamtime. Instead of relying on Streamtime's managed cloud services, you can deploy Kafka directly on your own Kubernetes clusters, whether they are on-premises or in the cloud.
+This approach provides you with full control over your environment while still benefiting from Streamtime's automation and management capabilities.
 
-## 2. IRSA role and policy
+## When to use BYOK
+BYOK is ideal when you have existing Kubernetes clusters that you want to integrate with Streamtime for Kafka management. It allows you to leverage your current infrastructure while benefiting from Streamtime's Kafka management capabilities.
 
-An OIDC identity provider must be associated with the cluster before any
-IRSA role can work, and **this has to be redone for every new cluster** —
-a fresh cluster gets a fresh OIDC ID, and any role still trusting the old
-one will fail with `AccessDenied: ... AssumeRoleWithWebIdentity`:
+## Key Features
+- **Self-Hosted Kafka**: Deploy and manage Kafka clusters on your own Kubernetes infrastructure.
+- **Full Control**: You retain ownership of your Kafka environment, networking, and security policies.
+- **Flexible Deployment**: Use your existing Kubernetes clusters, whether on-premises, in the cloud, or in a hybrid setup.
+- **Enterprise-Grade Automation**: Streamtime automates Kafka operations, including scaling, monitoring, and maintenance, while you control the underlying infrastructure. 
+- **Seamless Integration**: Easily integrate Kafka into your existing IT and security landscape without relying on external cloud providers.
+- **Multi-Tenancy Support**: Deploy multiple Kafka clusters within a single Kubernetes cluster, allowing for efficient resource utilization and isolation between different teams or environments.
+
+
+## How to Bootstrap a Kubernetes Fleet with BYOK
+Follow these steps to bootstrap a Kubernetes fleet using BYOK in Streamtime:
+1. **Select BYOK as Bootstrap Provider**
+    - In the Streamtime UI, click "Create Kubernetes Fleet".    
+    - Choose **BYOK** as your bootstrap provider.
+    ![Bootstrap Provider Selection]({{ site.baseurl }}/assets/images/byok/step-1.png)
+
+2. **Configure Tenancy & Sizing**
+    - Select the tenancy model: `shared`, `isolated`, or `dedicated`.
+    - Define your base domain, set the maximum tenancy (number of Kafka clusters per fleet), and specify the maximum Kafka units (throughput capacity).
+    - Choose the appropriate node size based on your workload (e.g., 1 Kafka unit = 20 MBps, recommended node: 4 vCPU / 16 GB RAM).
+    ![Tenancy & Sizing Configuration]({{ site.baseurl }}/assets/images/byok/step-2.png)
+3. **Placement Configuration**
+    - Optionally, specify provider and region details for placement metadata to optimize for latency, compliance, or cost.
+    - This step is optional but recommended for better performance and compliance.  
+    ![Placement Configuration]({{ site.baseurl }}/assets/images/byok/step-3.png)
+4. **Upload Your Kubernetes Configuration**
+    - Upload your Kubernetes `kubeconfig` file. This file contains the necessary credentials and configuration to connect to your existing Kubernetes clusters.
+    ![Upload Kubeconfig]({{ site.baseurl }}/assets/images/byok/step-4.png)
+5. **Deploy and Validate**
+    - Click **Deploy**. Streamtime will validate your kubeconfig and configure the Kubernetes fleet.
+    - Once deployed, the fleet status will show as "Healthy" and is ready for Kafka
+    ![byok detail view]({{ site.baseurl }}/assets/images/byok/detail-view.png)
+
+
+# API Reference
+
+## Create a Kubernetes Fleet with BYOK
 
 ```bash
-eksctl utils associate-iam-oidc-provider --cluster <cluster> --region <region> --approve
-aws eks describe-cluster --name <cluster> --region <region> \
-  --query 'cluster.identity.oidc.issuer' --output text
-# the hex string after /id/ is your OIDC ID — save it
+curl -X POST https://<streamtime-api-endpoint>/organizations/<your-org-id>/infrastructure/ \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "identifier": "additional-alpaca",
+    "infra_type": "byok",
+    "domain": "<your-domain>.com",
+    "max_tenants": 4,
+    "max_kafka_units": 17,
+    "tenancy_mode": "Shared",
+    "advanced_config": {
+        "kubeconfig": "<your-kubeconfig-string>"
+    },
+    "placement_config": {},
+    "organization": "<your-org-id>"
+}'
 ```
 
-The only IRSA role BYOK requires is for the **EBS CSI driver**. The
-Streamtime agent itself doesn't need direct AWS API access — it operates
-through a Kubernetes `cluster-admin` binding (see [Section 5](#5-generating-a-kubeconfig-for-automatic-installation)),
-not an IAM role.
-
-Create the EBS CSI role with a trust policy scoped to the OIDC provider,
-condition `<oidc-host>:sub = system:serviceaccount:kube-system:ebs-csi-controller-sa`,
-and attach the `AmazonEBSCSIDriverPolicy` managed policy. If you're
-rebuilding a cluster and the role already exists, update its trust policy
-to the new OIDC provider rather than recreating the role — and if your SSO
-role can't call `iam:UpdateAssumeRolePolicy`, create a new role (e.g.
-suffixed `_v3`) instead of fighting the permission.
-
-Before installing the addon, double-check the trust policy doesn't still
-contain a literal placeholder OIDC ID — that's the most common cause of the
-addon's controller pods crash-looping with `AccessDenied` on
-`AssumeRoleWithWebIdentity`.
-
-## 3. IP addressing for pods and services
-
-The VPC CNI assigns each pod a routable IP from its node's subnet, so
-subnet size — not just node count — caps how many pods will schedule.
-Undersized subnets showing up as pods stuck `Pending` is a known failure
-mode; size subnets for your target node count with headroom, not just the
-starting count.
-
-## 4. Load balancer and default storage class
-
-- **Load balancer**: no separate AWS Load Balancer Controller install is
-  needed. Kong Ingress is exposed via a `Service` of type `LoadBalancer`,
-  which EKS's in-tree cloud provider turns into a classic ELB
-  automatically.
-- **EBS CSI driver + default StorageClass**: EKS 1.23+ dropped the in-tree
-  EBS provisioner, so `aws-ebs-csi-driver` must be installed as an addon
-  (using the IRSA role above), and a default `StorageClass` must exist:
-  ```yaml
-  apiVersion: storage.k8s.io/v1
-  kind: StorageClass
-  metadata:
-    name: ebs-sc
-    annotations:
-      storageclass.kubernetes.io/is-default-class: 'true'
-  provisioner: ebs.csi.aws.com
-  volumeBindingMode: WaitForFirstConsumer
-  parameters:
-    type: gp3
-  ```
-  Skipping this is the most common cause of a stuck bootstrap: without a
-  default `StorageClass`, Loki and Prometheus (and any other PVC-backed
-  workload) stay `Pending` forever, which surfaces as the bootstrap
-  workflow timing out after roughly 30 minutes. If that happens, check
-  `kubectl get pods -A | grep Pending`, apply the `StorageClass` above if
-  it's missing, then:
-  ```bash
-  helm uninstall kafka-fleet-manager-loki -n monitoring
-  kubectl delete pvc --all -n monitoring
-  ```
-  and retry the fleet.
-
-## 5. Generating a kubeconfig for automatic installation
-
-The fleet-manager orchestrator expects a **static bearer token**, not an
-exec-based credential plugin, and it's strict about the exact structure —
-getting this wrong surfaces as `TypeError: string indices must be integers,
-not 'str'` in the bootstrap workflow rather than as an upload-time
-validation error.
-
-1. Create a service account and bind it to `cluster-admin`:
-   ```bash
-   kubectl create serviceaccount streamtime-admin -n kube-system
-   kubectl create clusterrolebinding streamtime-admin-binding \
-     --clusterrole=cluster-admin \
-     --serviceaccount=kube-system:streamtime-admin
-   ```
-2. Generate a token (shown once — save it):
-   ```bash
-   kubectl create token streamtime-admin -n kube-system --duration=24h
-   ```
-   Regenerate with the same command and re-upload if a long-running BYOK
-   cluster's fleet connection drops after the token expires.
-3. Grab the endpoint and CA data:
-   ```bash
-   aws eks describe-cluster --name <cluster> --region <region> --query 'cluster.endpoint' --output text
-   aws eks describe-cluster --name <cluster> --region <region> --query 'cluster.certificateAuthority.data' --output text
-   ```
-4. Assemble the kubeconfig in exactly this shape:
-   ```yaml
-   apiVersion: v1
-   kind: Config
-   clusters:
-   - cluster:
-       server: https://<endpoint>
-       certificate-authority-data: <ca-data>
-     name: <cluster-name>
-   contexts:
-   - context:
-       cluster: <cluster-name>
-       user: streamtime-admin
-     name: <cluster-name>-context
-   current-context: <cluster-name>-context
-   users:
-   - name: streamtime-admin
-     user:
-       token: <token>
-   ```
-   Three rules the workflow enforces strictly:
-   - `clusters[].name` must be a short cluster name, **not** the cluster ARN.
-   - `users[].user` must be a **nested object** containing `token:` — a flat
-     `user: <token>` string will fail.
-   - Spaces only, no tabs, anywhere in the file.
-5. Paste the file contents into the fleet's kubeconfig field in the
-   Streamtime UI (or `POST /organizations/<org>/fleets/<fleet_id>/kubeconfig/`
-   if you're driving it via API).
-
-After upload, `InstallStreamtimeAgentWorkflow` and
-`BootstrapFleetClusterWorkflow` install the fleet's Helm charts (Kong,
-Strimzi, Confluent operator, Prometheus, Loki, and others). Watch
-`kubectl get pods -n streamtime-agent -w` and the Temporal UI for progress.
+**Response:**
+```json
+{
+    "id": "bfca99b0-35a5-4490-9cc4-40296910f76d",
+    "organization": "acme",
+    "domain": "<your-domain>.com",
+    "identifier": "additional-alpaca",
+    "provisioner_name": null,
+    "destroyer_name": null,
+    "infra_type": "byok",
+    "tenancy_mode": "Shared",
+    "max_tenants": 4,
+    "max_kafka_units": 17,
+    "kubeconfig": null,
+    "kubeconfig_str": null,
+    "metadata": {},
+    "prometheus_endpoint": null,
+    "opencost_endpoint": null,
+    "loki_endpoint": null,
+    "loadbalancer_dns": null,
+    "placement_config": {},
+    "advanced_config": {
+        "kubeconfig": "<your-kubeconfig-string>"
+    },
+    "advanced_properties": {},
+    "status": "Pending",
+    "created_at": "2025-07-17T04:37:33.316063Z",
+    "updated_at": "2025-07-17T04:37:33.316090Z",
+    "network": null
+}
+```


### PR DESCRIPTION
## Summary
Adds a BYOK-with-AWS prerequisites page covering the five items from #1131:
sizing, IRSA role/policy, pod/service IP addressing, load balancer +
default storage class, and static-token kubeconfig generation.

Closes streamtime-ai/fleet-manager#1131